### PR TITLE
Removed the scipy v1.16 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "decoupler"
-version = "2.1.3"
+version = "2.1.4"
 description = "Python package to perform enrichment analysis from omics data."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Since the issue which required the old scipy package with statsmodels(https://github.com/statsmodels/statsmodels/issues/9584) is fixed now, there is no need to include the old version as a dependency.