### PR TITLE
Fix op.translate HCOP URL after EBI FTP drop (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## 2.1.6
+
+### Bugfixes
+- Fixed `op.translate` (and every `op.resource` call for non-human organisms) failing with HTTP 404 after HGNC dropped the `genenames/` subtree from the EBI FTP mirror; the HCOP fifteen-column files are now fetched from the new HGNC Google Cloud Storage bucket (#303)
+- Removed a redundant `pd.read_csv` call in `op.translate` that re-downloaded the HCOP file a second time and bypassed the retry logic in `_download`
+
 ## 2.1.5
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "decoupler"
-version = "2.1.5"
+version = "2.1.6"
 description = "Python package to perform enrichment analysis from omics data."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/decoupler/op/_translate.py
+++ b/src/decoupler/op/_translate.py
@@ -181,7 +181,9 @@ def translate(
     elif target_organism == "fruitfly":
         target_col = "fruit fly_symbol"
     # Process orthologs
-    url = f"https://storage.googleapis.com/public-download-files/hcop/human_{target_organism}_hcop_fifteen_column.txt.gz"
+    url = (
+        f"https://storage.googleapis.com/public-download-files/hcop/human_{target_organism}_hcop_fifteen_column.txt.gz"
+    )
     map_df = _download(url, verbose=verbose)
     map_df = _bytes_to_pandas(map_df, low_memory=False, compression="gzip", sep="\t")
     map_df["evidence"] = map_df["support"].apply(lambda x: len(x.split(",")))

--- a/src/decoupler/op/_translate.py
+++ b/src/decoupler/op/_translate.py
@@ -130,7 +130,7 @@ def translate(
     predictions tool. Briefings in Bioinformatics, 22(6), p.bbab155.
 
     For more information, please visit the HCOP website: https://www.genenames.org/tools/hcop/,
-    or alternatively check the bulk download FTP links page: https://ftp.ebi.ac.uk/pub/databases/genenames/hcop/
+    or the HCOP help page for bulk download details: https://www.genenames.org/help/hcop/
 
     Parameters
     ----------
@@ -181,10 +181,9 @@ def translate(
     elif target_organism == "fruitfly":
         target_col = "fruit fly_symbol"
     # Process orthologs
-    url = f"https://ftp.ebi.ac.uk/pub/databases/genenames/hcop/human_{target_organism}_hcop_fifteen_column.txt.gz"
+    url = f"https://storage.googleapis.com/public-download-files/hcop/human_{target_organism}_hcop_fifteen_column.txt.gz"
     map_df = _download(url, verbose=verbose)
     map_df = _bytes_to_pandas(map_df, low_memory=False, compression="gzip", sep="\t")
-    map_df = pd.read_csv(url, sep="\t", low_memory=False)
     map_df["evidence"] = map_df["support"].apply(lambda x: len(x.split(",")))
     map_df = map_df[map_df["evidence"] >= min_evidence]
     map_df = map_df[["human_symbol", target_col]]


### PR DESCRIPTION
## Summary
- Fixes #303: HGNC has removed the entire `/pub/databases/genenames/` subtree from the EBI FTP mirror, so every `op.translate` call — and every `op.resource(..., organism=...)` call for a non-human organism — was failing with `HTTPError: 404`. The HCOP fifteen-column files are now fetched from HGNC's public Google Cloud Storage bucket (`https://storage.googleapis.com/public-download-files/hcop/...`), which is where HGNC currently publishes them (confirmed via bucket listing; `anole_lizard` object was last updated 2026-03-27). The move is only documented on https://www.genenames.org/help/hcop/ — there's no dedicated announcement on the HGNC news page, which is likely why this went unnoticed until the FTP directory was actually taken down.
- Drops a stray `pd.read_csv(url, ...)` at the end of `op.translate`'s download block that was silently re-downloading the HCOP file a second time immediately after `_download` + `_bytes_to_pandas` had already produced `map_df`, doubling the network cost per call and bypassing the retry logic in `_download`.
- Bumps version to `2.1.6` and adds a CHANGELOG entry.

## Test plan
- [x] `PYTHONPATH=src pytest tests/op/test_translate.py` — 7 passed (including `test_translate` parametrized over `mouse`, `anole_lizard`, and `fruitfly`, which hits the live bucket)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)